### PR TITLE
Adds exclude configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ podfiles:
   - "https://git.hooli.xyz/ios/bro2bro/raw/master/Podfile.lock"
 pods:
   - Google-Mobile-Ads-SDK
+exclude:
+  - BABCropperView
 ```
 
 |key|meaning|
@@ -48,6 +50,7 @@ pods:
 |mirror.github.endpoint|API Endpoint of your GitHub api|
 |podfiles|List of __Podfile.lock__ in __Plain Text__ format|
 |pods|List of additional Pods you would like to add|
+|exclude|List of Pods you would like to exclude|
 
 We use Jenkins to run the synchronize process twice daily. To do that use the following command:
 

--- a/lib/updater/configuration.rb
+++ b/lib/updater/configuration.rb
@@ -21,6 +21,10 @@ class Configuration
     @yaml['pods']
   end
 
+  def exclude
+    @yaml['exclude']
+  end
+
   def mirror
     context = @yaml['mirror']
     Mirror.new(

--- a/lib/updater/configuration.rb
+++ b/lib/updater/configuration.rb
@@ -21,8 +21,8 @@ class Configuration
     @yaml['pods']
   end
 
-  def exclude
-    @yaml['exclude']
+  def excluded_pods
+    @yaml['excluded_pods']
   end
 
   def mirror

--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -74,6 +74,8 @@ module PodSynchronize
         pods_dependencies << @config.pods
         
         pods_dependencies.flatten!.uniq!
+
+        pods_dependencies.reject! { |dependency| @config.exclude.include? dependency }
       end
 
       def run

--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -75,7 +75,7 @@ module PodSynchronize
         
         pods_dependencies.flatten!.uniq!
 
-        pods_dependencies.reject! { |dependency| @config.exclude.include? dependency }
+        pods_dependencies.reject! { |dependency| @config.excluded_pods.include? dependency }
       end
 
       def run

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -36,6 +36,13 @@ describe Configuration do
     end
   end
 
+  describe '#exclude' do
+    it 'should parse the exclude list correctly' do
+      expected_result = ["BABCropperView"]
+      expect(@config.exclude).to eql(expected_result)
+    end
+  end
+
   describe "#mirror" do
     it 'should have the correct @specs_push_url' do
       expect(@config.mirror.specs_push_url).to eql("git@git.hooli.xyz:pods-mirror/Specs.git")

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -36,10 +36,10 @@ describe Configuration do
     end
   end
 
-  describe '#exclude' do
-    it 'should parse the exclude list correctly' do
+  describe '#excluded_pods' do
+    it 'should parse the excluded_pods list correctly' do
       expected_result = ["BABCropperView"]
-      expect(@config.exclude).to eql(expected_result)
+      expect(@config.excluded_pods).to eql(expected_result)
     end
   end
 

--- a/spec/fixtures/api_client_config.yml
+++ b/spec/fixtures/api_client_config.yml
@@ -1,0 +1,16 @@
+---
+master_repo: https://github.com/CocoaPods/Specs.git
+mirror:
+  specs_push_url: git@git.hooli.xyz:pods-mirror/Specs.git
+  source_push_url: git@git.hooli.xyz:pods-mirror
+  source_clone_url: git://git.hooli.xyz/pods-mirror
+  github:
+    acccess_token: 0y83t1ihosjklgnuioa
+    organisation: pods-mirror
+    endpoint: https://git.hooli.xyz/api/v3
+podfiles:
+  - "https://raw.githubusercontent.com/xing/XNGAPIClient/master/Example/Podfile.lock"
+pods:
+  - Google-Mobile-Ads-SDK
+excluded_pods:
+  - SSKeychain

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -14,3 +14,5 @@ podfiles:
   - "https://git.hooli.xyz/ios/bro2bro/raw/master/Podfile.lock"
 pods:
   - Google-Mobile-Ads-SDK
+exclude:
+  - BABCropperView

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -14,5 +14,5 @@ podfiles:
   - "https://git.hooli.xyz/ios/bro2bro/raw/master/Podfile.lock"
 pods:
   - Google-Mobile-Ads-SDK
-exclude:
+excluded_pods:
   - BABCropperView

--- a/spec/synchronize_spec.rb
+++ b/spec/synchronize_spec.rb
@@ -1,0 +1,23 @@
+describe PodSynchronize::Command::Synchronize do
+
+  before :all do
+    @sync = PodSynchronize::Command::Synchronize.new(CLAide::ARGV.new(['./spec/fixtures/api_client_config.yml']))
+    Dir.mktmpdir { |dir| @sync.setup(temp_path: dir) }
+  end
+
+  describe "#dependencies" do
+    it "resolves the dependencies correctly" do
+      expected_result = [
+        "AFNetworking",
+        "Expecta",
+        "OCMock",
+        "OHHTTPStubs",
+        "XNGAPIClient",
+        "XNGOAuth1Client",
+        "Google-Mobile-Ads-SDK",
+      ]
+      expect(@sync.dependencies).to eql(expected_result)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds a new property `exclude` to the `configuration` class. This is helpful when you want to exclude pods from the synchronisation without removing those from the `Podfile`.