### PR TITLE
Adapt gem to new CocoaPods master spec repo structure

### DIFF
--- a/lib/updater/specs.rb
+++ b/lib/updater/specs.rb
@@ -10,7 +10,7 @@ class Specs
   end
 
   def pods
-    @pods ||= Dir.glob(File.join(@specs_root, '*')).map do |pod_path|
+    @pods ||= traverse(@specs_root).flatten.map do |pod_path|
       pod = Pod.new(path: pod_path)
       @whitelist.any? && !@whitelist.include?(pod.name) ? nil : pod
     end.compact
@@ -25,6 +25,22 @@ class Specs
 
   def git
     @git ||= Git.new(path: @path)
+  end
+
+  private
+
+  def traverse(working_dir)
+    whitelist = %w{0 1 2 3 4 5 6 7 8 9 a b c d e f}
+    pods = []
+    Dir.glob(File.join(working_dir, '*')).map do |dir|
+      dir_name = dir.split(File::SEPARATOR).last
+      if whitelist.include? dir_name
+        pods << traverse(dir)
+      else
+        pods << dir
+      end
+    end
+    pods
   end
 
 end

--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -21,7 +21,7 @@ module PodSynchronize
       def setup(temp_path:)
         @config = Configuration.new(path: @yml_path)
         @master_specs = Specs.new(path: File.join(temp_path, 'master'), whitelist: dependencies, specs_root: 'Specs')
-        @internal_specs = Specs.new(path: File.join(temp_path, 'local'))
+        @internal_specs = Specs.new(path: File.join(temp_path, 'local'), specs_root: '.')
       end
 
       def bootstrap

--- a/spec/fixtures/api_client_config.yml
+++ b/spec/fixtures/api_client_config.yml
@@ -13,4 +13,4 @@ podfiles:
 pods:
   - Google-Mobile-Ads-SDK
 excluded_pods:
-  - SSKeychain
+  - SAMKeychain


### PR DESCRIPTION
CocoaPods master specs repository had a structure change 2 weeks ago (you can read more about it [here](http://blog.cocoapods.org/Sharding/)), this PR adapts the gem to handle the new structure and also keeps it compatible with the old one (in case you're using [Old-Specs](https://github.com/CocoaPods/Old-Specs) for instance).

To discuss: there's probably a better way to traverse the new structure, but during my tests I didn't find any huge performance drawback on doing it this way. 