### PR TITLE
Add missing require statement

### DIFF
--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'openssl'
 
 module PodSynchronize
   class Command


### PR DESCRIPTION
`synchronize` command crashes with the following stack trace in Ruby 2.3.1

```
/Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:71:in `block in dependencies': uninitialized constant PodSynchronize::Command::Synchronize::OpenSSL (NameError)
Did you mean?  OpenStruct
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:70:in `each'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:70:in `dependencies'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:23:in `setup'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:83:in `block in run'
	from /Users/jenkins/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/lib/updater/synchronize.rb:82:in `run'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/claide-0.8.2/lib/claide/command.rb:312:in `run'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/gems/pod-synchronize-0.4.0/bin/pod-synchronize:11:in `<top (required)>'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/bin/pod-synchronize:23:in `load'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/bin/pod-synchronize:23:in `<main>'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
	from /Users/jenkins/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'
```

I assume `openssl` namespace it's not available, adding a require statement fixes this, but not sure if openssl is included by default in Ruby or do we have to add a runtime dependency in the gemspec.