### PR TITLE
Handle excluded_pods not set in configuration file

### DIFF
--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -76,7 +76,9 @@ module PodSynchronize
         
         pods_dependencies.flatten!.uniq!
 
-        pods_dependencies.reject! { |dependency| @config.excluded_pods.include? dependency }
+        pods_dependencies.reject! { |dependency| @config.excluded_pods.include? dependency } unless @config.excluded_pods.nil?
+
+        pods_dependencies
       end
 
       def run


### PR DESCRIPTION
I broke this during https://github.com/xing/XNGPodsSynchronizer/pull/6, I think it shouldn't be mandatory to have that in the configuration file.