### PR TITLE
Handle git source not available in Podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/xing/XNGPodsSynchronizer.svg?branch=master)](https://travis-ci.org/xing/XNGPodSynchronizer)
 [![Coverage Status](https://coveralls.io/repos/xing/XNGPodsSynchronizer/badge.svg?branch=master)](https://coveralls.io/r/xing/XNGPodSynchronizer?branch=master)
 
-XNGPodSynchronizer reads `Podfile.locks` of your projects, copies the `.podspec`s from the CocoaPods master repository and mirrors it to your own `git` repository (e.g. GitHub Enterprise). This helps you get independent from `github.com`.
+XNGPodSynchronizer reads `Podfile.locks` of your projects, copies the `.podspec`s from the CocoaPods master repository and mirrors it to your own `git` repository (e.g. GitHub Enterprise). This helps you get independent from `github.com` and avoids the need of cloning the full CocoaPods master repository, which might speed up your builds on CI.
 
 ## Installation
 
@@ -57,6 +57,10 @@ We use Jenkins to run the synchronize process twice daily. To do that use the fo
 ```
 $ pod-synchronize synchronize config.yml
 ```
+
+## Known issues
+
+At the moment this gem only handles `git` [sources](https://guides.cocoapods.org/syntax/podspec.html#source) correctly. `HTTP` sources are partly supported (see [#12](https://github.com/xing/XNGPodsSynchronizer/pull/12)) and `svn`, `hg` support is missing.
 
 ## TODO
 

--- a/lib/updater/pod.rb
+++ b/lib/updater/pod.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 class Pod
   attr_reader :path, :name
 
@@ -13,7 +15,15 @@ class Pod
   end
 
   def git_source
-    versions.sort.last.contents["source"]["git"]
+    source = versions.sort.last.contents["source"]["git"]
+    source ||= begin
+      http_source = versions.sort.last.contents["source"]["http"]
+      uri = URI.parse(http_source)
+      host = uri.host.match(/www.(.*)/).captures.first
+      scheme = "git"
+      path = uri.path.split("/").take(3).join("/").concat(".git")
+      URI::Generic.build({scheme: scheme, host: host, path: path}).to_s
+    end
   end
 
   def save


### PR DESCRIPTION
According to the [Podspec specification](https://guides.cocoapods.org/syntax/podspec.html#source), the source can be: `git`, `svn`, `hg` and `http`. This is a start to support `http` as a fallback if `git` is not there, which I believe is the second most used one.

I believe we should also handle in [PodSynchronize::Synchronize#update_specs](https://github.com/xing/XNGPodsSynchronizer/blob/master/lib/updater/synchronize.rb#L38), but I don't have a good solution for the `http` case, because it basically can be anything. 