### PR TITLE
[WIP] Add support for downloading podspecs via api

### DIFF
--- a/lib/updater/configuration.rb
+++ b/lib/updater/configuration.rb
@@ -5,6 +5,7 @@ class Configuration
   attr_reader :yaml
   Mirror = Struct.new(:specs_push_url, :source_push_url, :source_clone_url, :github)
   Github = Struct.new(:access_token, :organisation, :endpoint)
+  APIPodfile = Struct.new(:org, :repo, :path)
 
   def initialize(path)
     @yaml = YAML.load(ERB.new(File.new(path).read).result)
@@ -33,6 +34,17 @@ class Configuration
       context['source_push_url'],
       context['source_clone_url'],
       github)
+  end
+
+  def api_podfiles
+    context = @yaml['api_podfiles']
+    context.map do |podfile|
+      APIPodfile.new(
+        podfile['org'],
+        podfile['repo'],
+        podfile['path']
+        )
+    end
   end
 
   private

--- a/lib/updater/configuration.rb
+++ b/lib/updater/configuration.rb
@@ -16,7 +16,7 @@ class Configuration
   end
 
   def podfiles
-    @yaml['podfiles']
+    @yaml['podfiles'] || []
   end
 
   def pods
@@ -37,8 +37,8 @@ class Configuration
   end
 
   def api_podfiles
-    context = @yaml['api_podfiles']
-    context.map do |podfile|
+    context = @yaml['api_podfiles'] || []
+    podfiles = context.map do |podfile|
       APIPodfile.new(
         podfile['org'],
         podfile['repo'],

--- a/lib/updater/specs.rb
+++ b/lib/updater/specs.rb
@@ -12,7 +12,7 @@ class Specs
   def pods
     @pods ||= traverse(@specs_root).flatten.map do |pod_path|
       pod = Pod.new(pod_path)
-      @whitelist.any? && !@whitelist.include?(pod.name) ? nil : pod
+      @whitelist.any? && !@whitelist.include?(pod.name) ? nil : pod unless @whitelist.nil?
     end.compact
   end
 

--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -70,14 +70,12 @@ module PodSynchronize
       def dependencies
         pods_dependencies = []
 
-        (@config.api_podfiles || []).each do |podfile|
-          url = "#{@config.mirror.github.endpoint}/repos/#{podfile.org}/#{podfile.repo}/contents/#{podfile.path}"
-          download_url = get_download_url(url, @config.mirror.github.access_token)
-          podfile_contents = download_podfile(download_url)
+        @config.api_podfiles.each do |podfile|
+          podfile_contents = download_podfile(podfile)
           pods_dependencies << YAML.load(podfile_contents)["SPEC CHECKSUMS"].keys
         end
 
-        (@config.podfiles || []).each do |podfile|
+        @config.podfiles.each do |podfile|
           podfile_contents = open(podfile, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}) { |io| io.read }
           pods_dependencies << YAML.load(podfile_contents)["SPEC CHECKSUMS"].keys
         end
@@ -105,7 +103,9 @@ module PodSynchronize
           JSON.parse(result)["download_url"]
         end
 
-        def download_podfile(download_url)
+        def download_podfile(podfile)
+          url = "#{@config.mirror.github.endpoint}/repos/#{podfile.org}/#{podfile.repo}/contents/#{podfile.path}"
+          download_url = get_download_url(url, @config.mirror.github.access_token)
           `/usr/bin/curl #{download_url} -H "Authorization: token #{@config.mirror.github.access_token}"`
         end
     end

--- a/lib/updater/synchronize.rb
+++ b/lib/updater/synchronize.rb
@@ -1,6 +1,5 @@
 require 'open-uri'
 require 'openssl'
-require 'net/http'
 require 'json'
 
 module PodSynchronize


### PR DESCRIPTION
This adds support for using the GitHub API to download the Podfile.lock instead of the plain URL download. This is helpful if you are in a corporate environment and your GitHub sits behind a Firewall and needs Authentication. 

Appending the access token in the URL in the config did not work for me so I had to do it this way.

Sample config:

```yaml
...
github:
    acccess_token: my_access_token
    organisation: mt-ios-pods
    endpoint: https://github.corp.ebay.com/api/v3
api_podfiles:
  - org: hooli
    repo: not-hot-dog-ios
    path: Podfile.lock
...
```

Needs:

* [ ] Refactoring
* [ ] Documentation