### PR TITLE
Avoid processing http source if host doesn't include GitHub

### DIFF
--- a/lib/updater/pod.rb
+++ b/lib/updater/pod.rb
@@ -19,6 +19,7 @@ class Pod
     source ||= begin
       http_source = versions.sort.last.contents["source"]["http"]
       uri = URI.parse(http_source)
+      return nil unless uri.host.include? "github.com"
       host = uri.host.match(/www.(.*)/).captures.first
       scheme = "git"
       path = uri.path.split("/").take(3).join("/").concat(".git")


### PR DESCRIPTION
This should "fix": https://github.com/xing/XNGPodsSynchronizer/pull/12#issuecomment-309778508, well basically it will give us the old behaviour: for http sources that are not hosted in GitHub.com we will skip the URL parsing and the repository won't be mirrored.

Ideally, it would be great if we could find a way to get a git repo (for mirroring) with the Pod name from somewhere else besides the podspec, but I don't believe this is possible.

Alternatively, we could create our own git repository versioning the file hosted in the http source (for binary dependencies), a bit crazy but I think it'll be cool and will properly "mirror" the contents.