### PR TITLE
Evaluate yaml file with erb before parsing

### DIFF
--- a/lib/updater/configuration.rb
+++ b/lib/updater/configuration.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 class Configuration
   attr_reader :yaml
@@ -6,7 +7,7 @@ class Configuration
   Github = Struct.new(:access_token, :organisation, :endpoint)
 
   def initialize(path)
-    @yaml = YAML.load_file(path)
+    @yaml = YAML.load(ERB.new(File.new(path).read).result)
   end
 
   def master_repo


### PR DESCRIPTION
It'll be helpful to evaluate the configuration file with erb before parsing the yaml syntax. This allows us to do stuff like [this](https://github.com/Ruenzuo/ubiquitous-spork/blob/master/config.yml#L9) and store secrets in environment variables, useful for container based CI systems.